### PR TITLE
Disable Chromium sandbox for screenshots

### DIFF
--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -1,0 +1,26 @@
+name: Capture Screenshot on PR
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  screenshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install puppeteer
+        run: npm install puppeteer
+      - name: Capture screenshot
+        run: node screenshot.mjs
+      - name: Comment on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          base64=$(cat screenshot.txt)
+          gh api repos/$REPO/issues/$PR_NUMBER/comments -f body="![Screenshot](data:image/png;base64,$base64)"

--- a/screenshot.mjs
+++ b/screenshot.mjs
@@ -1,0 +1,32 @@
+import puppeteer from 'puppeteer';
+import { readFile, writeFile } from 'fs/promises';
+import path from 'path';
+
+async function main() {
+  // Launch headless browser. The GitHub Actions environment lacks a sandbox
+  // which Chromium normally expects, so disable the sandbox to avoid errors.
+  const browser = await puppeteer.launch({
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+  const page = await browser.newPage();
+
+  // Navigate to the built-in index.html using a file URL
+  const filePath = path.join(process.cwd(), 'index.html');
+  const url = 'file://' + filePath;
+  await page.goto(url);
+
+  // Set a small viewport so the base64 output fits in a comment
+  await page.setViewport({ width: 400, height: 600 });
+
+  // Capture screenshot
+  const imagePath = 'screenshot.png';
+  await page.screenshot({ path: imagePath });
+  await browser.close();
+
+  // Convert the screenshot to base64 and save to a text file
+  const image = await readFile(imagePath);
+  const base64 = image.toString('base64');
+  await writeFile('screenshot.txt', base64);
+}
+
+main();


### PR DESCRIPTION
## Summary
- disable Chromium sandbox in `screenshot.mjs` to allow Puppeteer to run in GitHub Actions

## Testing
- `node --test`
